### PR TITLE
Avoid shifts of negative values inflateMark()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode7.1
+osx_image: xcode7.3
 language: objective-c
 before_install:
   - brew update

--- a/ThirdParty/zlib-1.2.8/inflate.c
+++ b/ThirdParty/zlib-1.2.8/inflate.c
@@ -1504,9 +1504,10 @@ z_streamp strm;
 {
     struct inflate_state FAR *state;
 
-    if (strm == Z_NULL || strm->state == Z_NULL) return -1L << 16;
+	if (strm == Z_NULL || strm->state == Z_NULL)
+		return (long)(((unsigned long)0 - 1) << 16);
     state = (struct inflate_state FAR *)strm->state;
-    return ((long)(state->back) << 16) +
+    return (long)(((unsigned long)((long)state->back)) << 16) +
         (state->mode == COPY ? state->length :
             (state->mode == MATCH ? state->was - state->length : 0));
 }


### PR DESCRIPTION
The C standard says that bit shifts of negative integers is
undefined.  This casts to unsigned values to assure a known
result.
